### PR TITLE
Fix for C++14 compilers 

### DIFF
--- a/src/Helper.h
+++ b/src/Helper.h
@@ -25,6 +25,9 @@ along with nmfgpu4R.  If not, see <http://www.gnu.org/licenses/>.
 #include "nmfgpu.h"
 #include <Rcpp.h>
 
+#ifdef __cpp_lib_make_unique
+using std::make_unique;
+#else
 namespace Details {
   /** Implementation of a C++14 make_unique function, as it is not proposed by the C++11 standard.
   @tparam T Type of the object to be constructed.
@@ -36,6 +39,10 @@ namespace Details {
   std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
   }
+}
+#endif
+
+namespace Details {
   
   void fillDenseMatrixDescriptionFromRObject(nmfgpu::MatrixDescription<float>& desc, std::unique_ptr<std::vector<float>>& values, Rcpp::RObject input);
   


### PR DESCRIPTION
I've been discussing C++14 compliance issues with the CRAN maintainers. This package is currently failing R CMD check with gcc 6.1 because the make_unique function is already defined in the standard library and this creates a namespace clash. I've added a check for the macro `__cpp_lib_make_unique` which is defined if make_unique is defined in `<memory>`. See

https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations#detail.cpp14.n3656

Tested on Fedora 23 with gcc 5.3.1 (default standard gnu++98) and on Fedora 24 beta with gcc 6.1.1 (default standard gnu++14).
